### PR TITLE
Fixed bug in executing result filter in macro

### DIFF
--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
@@ -6,6 +6,7 @@ import cz.cuni.lf1.lge.ThunderSTORM.FormulaParser.SyntaxTree.Node;
 import cz.cuni.lf1.lge.ThunderSTORM.FormulaParser.SyntaxTree.RetVal;
 import cz.cuni.lf1.lge.ThunderSTORM.UI.GUI;
 import cz.cuni.lf1.lge.ThunderSTORM.UI.Help;
+import cz.cuni.lf1.lge.ThunderSTORM.UI.MacroParser;
 import cz.cuni.lf1.lge.ThunderSTORM.estimators.PSF.MoleculeDescriptor.Units;
 import cz.cuni.lf1.lge.ThunderSTORM.rendering.ui.EmptyRendererUI;
 import cz.cuni.lf1.lge.ThunderSTORM.util.GridBagHelper;

--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
@@ -102,6 +102,7 @@ public class ResultsFilter extends PostProcessingModule {
 
                 @Override
                 public void finishJob(Void nothing) {
+                    applyButton.setEnabled(true);
                     int filtered = all - model.getRowCount();
                     addOperationToHistory(new DefaultOperation());
                     String be = ((filtered > 1) ? "were" : "was");

--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/results/ResultsFilter.java
@@ -85,12 +85,17 @@ public class ResultsFilter extends PostProcessingModule {
     @Override
     protected void runImpl() {
         final String filterText = formulaParameter.getValue();
-        if((!applyButton.isEnabled()) || (filterText == null) || ("".equals(filterText))) {
+        if((filterText == null) || ("".equals(filterText))) {
             return;
+        }
+        if(!applyButton.isEnabled() && !MacroParser.isRanFromMacro()) {
+        	return;
         }
         filterTextField.setBackground(Color.WHITE);
         try {
-            applyButton.setEnabled(false);
+        	if (!MacroParser.isRanFromMacro()) {
+        		applyButton.setEnabled(false);
+        	}
             saveStateForUndo();
             final int all = model.getRowCount();
             new WorkerThread<Void>() {
@@ -102,7 +107,6 @@ public class ResultsFilter extends PostProcessingModule {
 
                 @Override
                 public void finishJob(Void nothing) {
-                    applyButton.setEnabled(true);
                     int filtered = all - model.getRowCount();
                     addOperationToHistory(new DefaultOperation());
                     String be = ((filtered > 1) ? "were" : "was");


### PR DESCRIPTION
Hi,

I fixed a bug which caused by disabling the apply button when using the result filter. I tracked the error, it because in WorkerThread.java, the worker thread will only execute exFinally() when it's not in Macro mode, but in ResultsFilter, it disable the apply button but rely on exFinally() to enable it, this will prevent further use of the Results Filter.

Best,
Wei OUYANG