### PR TITLE
Fix estimator NullPointerException issue

### DIFF
--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/UI/MacroParser.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/UI/MacroParser.java
@@ -39,9 +39,9 @@ public class MacroParser {
                        List<IRendererUI> knowRenderers) {
         this.knownFilters = knowFilters;
         if (isBiplane) {
-            this.knownEstimators = (List<IEstimatorUI>) knowEstimators;
-        } else {
             this.knownBiplaneEstimators = (List<IBiplaneEstimatorUI>) knowEstimators;
+        } else {
+            this.knownEstimators = (List<IEstimatorUI>) knowEstimators;
         }
         this.knownDetectors = knowDetectors;
         this.knownRenderers = knowRenderers;


### PR DESCRIPTION
The condition variable is reversed, which cause the knownEstimators to be NULL, instead of knownBiplaneEstimators when working with the macro.