### PR TITLE
Error fixed in drift correction

### DIFF
--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/drift/CorrelationDriftEstimator.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/drift/CorrelationDriftEstimator.java
@@ -91,7 +91,8 @@ public class CorrelationDriftEstimator {
             }
 
             //find maxima in low res image
-            multiplyImageByGaussianMask(new Point2D.Double(driftXofImage[i - 1] + lowResPaddedSize / 2, driftXofImage[i - 1] + lowResPaddedSize / 2), lowResPaddedSize, lowResCrossCorrelationImage);
+            //multiplyImageByGaussianMask(new Point2D.Double(driftXofImage[i - 1] + lowResPaddedSize / 2, driftXofImage[i - 1] + lowResPaddedSize / 2), lowResPaddedSize, lowResCrossCorrelationImage);
+            multiplyImageByGaussianMask(new Point2D.Double(-driftXofImage[i - 1]/magnification + lowResPaddedSize / 2, -driftYofImage[i - 1]/magnification + lowResPaddedSize / 2), lowResPaddedSize, lowResCrossCorrelationImage);
             Point2D.Double lowResMaximumCoords = CorrelationDriftEstimator.findMaxima(lowResCrossCorrelationImage);
             lowResMaximumCoords = CorrelationDriftEstimator.findMaximaWithSubpixelPrecision(lowResMaximumCoords, 11, lowResCrossCorrelationImage);
 

--- a/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/drift/CorrelationDriftEstimator.java
+++ b/src/main/java/cz/cuni/lf1/lge/ThunderSTORM/drift/CorrelationDriftEstimator.java
@@ -91,7 +91,6 @@ public class CorrelationDriftEstimator {
             }
 
             //find maxima in low res image
-            //multiplyImageByGaussianMask(new Point2D.Double(driftXofImage[i - 1] + lowResPaddedSize / 2, driftXofImage[i - 1] + lowResPaddedSize / 2), lowResPaddedSize, lowResCrossCorrelationImage);
             multiplyImageByGaussianMask(new Point2D.Double(-driftXofImage[i - 1]/magnification + lowResPaddedSize / 2, -driftYofImage[i - 1]/magnification + lowResPaddedSize / 2), lowResPaddedSize, lowResCrossCorrelationImage);
             Point2D.Double lowResMaximumCoords = CorrelationDriftEstimator.findMaxima(lowResCrossCorrelationImage);
             lowResMaximumCoords = CorrelationDriftEstimator.findMaximaWithSubpixelPrecision(lowResMaximumCoords, 11, lowResCrossCorrelationImage);


### PR DESCRIPTION
In drift correction, the stack of images is decomposed in N steps, and correlation between each step is performed.
For improving the cross correlation, the image at each step is weighted by a Gaussian function centered on the position of the drift estimate at the previous step.
However, the computation of the center of the Gaussian function was wrong -> Sometime outside the image.
Now it is fixed.