### PR TITLE
pom.xml: swingbox-1.1-SNAPSHOT to swingbox-1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>net.sf.cssbox</groupId>
             <artifactId>swingbox</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>net.java.balloontip</groupId>


### PR DESCRIPTION
Update the swingbox dependency to point to 1.1 rather than 1.1-SNAPSHOT

swingbox-1.1 doesn't appear in the snapshot repository
https://oss.sonatype.org/content/repositories/snapshots/net/sf/cssbox/

but does appear in the central Maven repository
https://repo1.maven.org/maven2/net/sf/cssbox/swingbox/1.1